### PR TITLE
Remove "Quick Edit" admin link

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -241,6 +241,13 @@ function hidden_type_title() {
     <?php
 }
 
+function remove_quick_edit($actions, $post) {
+    if(get_post_type() == 'activity' || get_post_type() == 'bordr') {
+        unset($actions['inline hide-if-no-js']);
+    }
+    return $actions;
+}
+add_filter('post_row_actions','remove_quick_edit', 10, 2);
 
 // END ADMIN FUNCTIONS
 


### PR DESCRIPTION
This fixes issue #70, it's was possible to publish an incomplete activity (i.e skipping required fields) with the Quick Edit feature in WordPress Admin.

This commit hides the link for both activities and bordr stories.